### PR TITLE
Search episodes by link instead of title.

### DIFF
--- a/rebuildfm.go
+++ b/rebuildfm.go
@@ -111,7 +111,7 @@ func main() {
 	ep := flag.Arg(0)
 	if ep != "-" {
 		for _, i := range rss.Items.ItemList {
-			if strings.HasPrefix(i.Title, ep+":") {
+			if strings.HasSuffix(i.Link, ep+"/") {
 				err = play(i)
 				if err != nil {
 					log.Fatal(err)


### PR DESCRIPTION
This enables to play an Aftershow episode by e.g., `rebuildfm 93a'
instead of by`rebuildfm Aftershow 93'.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mattn/rebuildfm/4)

<!-- Reviewable:end -->
